### PR TITLE
First cut

### DIFF
--- a/ui/src/app/shared/services/parser.spec.ts
+++ b/ui/src/app/shared/services/parser.spec.ts
@@ -15,7 +15,7 @@ describe('parser:', () => {
         expect(line.errors).toBeNull();
         node = line.nodes[0];
         expect(node.group).toEqual('UNKNOWN_0');
-        expect(node.type).toEqual('source');
+        expect(node.type).toEqual('app');
         expect(node.name).toEqual('time');
         expect(node.options.size).toEqual(0);
         expect(node.optionsranges.size).toEqual(0);
@@ -59,6 +59,34 @@ describe('parser:', () => {
         expectChannels(node, 'foo');
     });
 
+    it('channel input with extended character set', () => {
+        parseResult = Parser.parse(':foo*/# > log', 'stream');
+        expect(parseResult.lines.length).toEqual(1);
+        line = parseResult.lines[0];
+        nodes = parseResult.lines[0].nodes;
+        expect(nodes.length).toEqual(1);
+        node = nodes[0];
+        expect(node.group).toEqual('UNKNOWN_0');
+        expect(node.type).toEqual('sink');
+        expect(node.name).toEqual('log');
+        expectRange(node.range, 10, 0, 13, 0);
+        expectChannels(node, 'foo*/#');
+    });
+
+    it('channel input with extended character set 2', () => {
+        parseResult = Parser.parse(':*/foo > :*bar/foo#', 'stream');
+        expect(parseResult.lines.length).toEqual(1);
+        line = parseResult.lines[0];
+        nodes = parseResult.lines[0].nodes;
+        expect(nodes.length).toEqual(1);
+        node = nodes[0];
+        expect(node.group).toEqual('UNKNOWN_0');
+        expect(node.type).toEqual('processor');
+        expect(node.name).toEqual('bridge');
+        expectRange(node.range, 7, 0, 8, 0);
+        expectChannels(node, '*/foo', '*bar/foo#');
+    });
+
     it('channel output', () => {
         parseResult = Parser.parse('time > :foo', 'stream');
         expect(parseResult.lines.length).toEqual(1);
@@ -71,6 +99,24 @@ describe('parser:', () => {
         expect(node.name).toEqual('time');
         expectRange(node.range, 0, 0, 4, 0);
         expectChannels(node, null, 'foo');
+    });
+
+    it('long running apps', () => {
+        parseResult = Parser.parse('aaa, bbb', 'stream');
+        expect(parseResult.lines.length).toEqual(1);
+        line = parseResult.lines[0];
+        nodes = parseResult.lines[0].nodes;
+        expect(nodes.length).toEqual(2);
+        node = nodes[0];
+        expect(node.group).toEqual('UNKNOWN_0');
+        expect(node.type).toEqual('app');
+        expect(node.name).toEqual('aaa');
+        expectRange(node.range, 0, 0, 3, 0);
+        node = nodes[1];
+        expect(node.group).toEqual('UNKNOWN_0');
+        expect(node.type).toEqual('app');
+        expect(node.name).toEqual('bbb');
+        expectRange(node.range, 5, 0, 8, 0);
     });
 
     it('options', () => {
@@ -146,6 +192,40 @@ describe('parser:', () => {
         error = parseResult.lines[0].errors[0];
         expect(error.message).toEqual('Expected format: name = taskapplication [options]');
         expectRange(error.range, 0, 0, 0, 0);
+    });
+
+    it('list of apps - error checking', () => {
+        parseResult = Parser.parse(':aaa > fff,bbb', 'stream');
+        error = parseResult.lines[0].errors[0];
+        expect(error.message).toEqual('Don\'t use comma with channels');
+        expectRange(error.range, 10, 0, 11, 0);
+        parseResult = Parser.parse('aaa,bbb > :zzz', 'stream');
+        error = parseResult.lines[0].errors[0];
+        expect(error.message).toEqual('Don\'t use comma with channels');
+        expectRange(error.range, 3, 0, 4, 0);
+        parseResult = Parser.parse('aaa | bbb, ccc', 'stream');
+        error = parseResult.lines[0].errors[0];
+        expect(error.message).toEqual('Don\'t mix pipe and comma');
+        expectRange(error.range, 4, 0, 5, 0);
+        parseResult = Parser.parse('aaa, bbb| ccc', 'stream');
+        error = parseResult.lines[0].errors[0];
+        expect(error.message).toEqual('Don\'t mix pipe and comma');
+        expectRange(error.range, 3, 0, 4, 0);
+
+        parseResult = Parser.parse('aaa | filter --expression=\'#jsonPath(payload,\'\'$.lang\'\')==\'\'en\'\'\'', 'stream');
+        console.log(parseResult);
+        expect(parseResult.lines[0].nodes[1].options.get('expression')).
+            toEqual('\'#jsonPath(payload,\'\'$.lang\'\')==\'\'en\'\'\'');
+
+        parseResult = Parser.parse('aaa --bbb=ccc,', 'stream');
+        error = parseResult.lines[0].errors[0];
+        expect(error.message).toEqual('Out of data');
+        expectRange(error.range, 14, 0, 15, 0);
+
+        parseResult = Parser.parse('aaa --bbb=\'ccc\',', 'stream');
+        error = parseResult.lines[0].errors[0];
+        expect(error.message).toEqual('Out of data');
+        expectRange(error.range, 16, 0, 17, 0);
     });
 
     it('error: task with extra data', () => {
@@ -276,8 +356,16 @@ describe('parser:', () => {
         parseResult = Parser.parse('bbb | bbb', 'stream');
         expect(parseResult.lines.length).toEqual(1);
         error = parseResult.lines[0].errors[0];
-        expect(error.message).toEqual('App \'bbb\' should be unique within the stream, use a label to differentiate multiple occurrences');
+        expect(error.message).toEqual('App \'bbb\' should be unique within the definition, use a label to differentiate multiple occurrences');
         expectRange(error.range, 6, 0, 9, 0);
+    });
+
+    it('error: label required unmanaged stream app', () => {
+        parseResult = Parser.parse('bbb, bbb', 'stream');
+        expect(parseResult.lines.length).toEqual(1);
+        error = parseResult.lines[0].errors[0];
+        expect(error.message).toEqual('App \'bbb\' should be unique within the definition, use a label to differentiate multiple occurrences');
+        expectRange(error.range, 5, 0, 8, 0);
     });
 
     it('error: rogue option name', () => {
@@ -389,6 +477,14 @@ describe('parser:', () => {
         parseResult = Parser.parse('aaa: time | log', 'stream');
         expect((<Parser.StreamApp>parseResult.lines[0].nodes[0]).label).toEqual('aaa');
         expect(parseResult.lines[0].nodes[0].name).toEqual('time');
+    });
+
+    it('check label unmanaged stream apps', () => {
+        parseResult = Parser.parse('aaa, bbb: aaa', 'stream');
+        expect((<Parser.StreamApp>parseResult.lines[0].nodes[0]).label).toBeUndefined;
+        expect((<Parser.StreamApp>parseResult.lines[0].nodes[1]).label).toEqual('bbb');
+        expect(parseResult.lines[0].nodes[0].name).toEqual('aaa');
+        expect(parseResult.lines[0].nodes[1].name).toEqual('aaa');
     });
 
     it('error: bad options 1', () => {

--- a/ui/src/app/shared/services/parser.ts
+++ b/ui/src/app/shared/services/parser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,15 +41,12 @@ class InternalParser {
         this.textlines = definitionsText.split('\n');
     }
 
-    private tokenListToStringList(tokens, delimiter) {
+    private tokenListToStringList(tokens) {
         if (tokens.length === 0) {
             return '';
         }
         let result = '';
         for (let t = 0; t < tokens.length; t++) {
-            if (t > 0) {
-                result = result + delimiter;
-            }
             result = result + tokens[t].data;
         }
         return result;
@@ -125,6 +122,25 @@ class InternalParser {
         }
     }
 
+    private peekDestinationComponentToken(mustMatchAndConsumeIfDoes: boolean): Token {
+        let t = this.peekAtToken();
+        if (t === null) {
+            throw {'msg': 'Out of data', 'start': this.text.length};
+        }
+        if (!(this.isKind(t, TokenKind.IDENTIFIER) || this.isKind(t, TokenKind.STAR) ||
+              this.isKind(t, TokenKind.SLASH) || this.isKind(t, TokenKind.HASH))) {
+           if (mustMatchAndConsumeIfDoes) {
+               throw {'msg': 'Tokens of kind ' + t.kind + ' cannot be used in a destination', 'start': t.start};
+           } else {
+               return null;
+           }
+        }
+        if (mustMatchAndConsumeIfDoes) {
+            this.nextToken();
+        }
+        return t;
+    }
+
     private eatToken(expectedKind: TokenKind): Token {
         const t = this.nextToken();
         if (t === null) {
@@ -137,7 +153,7 @@ class InternalParser {
         return t;
     }
 
-    // A destination reference is of the form ':'IDENTIFIER['.'IDENTIFIER]*
+    // A destination reference is of the form ':'(IDENTIFIER|STAR|SLASH|HASH)['.'(IDENTIFIER|STAR|SLASH|HASH]*
     private eatDestinationReference(tapAllowed: boolean): Parser.DestinationReference {
         const nameComponents = [];
         let t;
@@ -147,16 +163,21 @@ class InternalParser {
             throw {'msg': 'Destination must start with a \':\'', 'start': firstToken.start, 'end': firstToken.end};
         }
         if (!this.isNextTokenAdjacent()) {
-        t = this.peekAtToken();
+            t = this.peekAtToken();
             if (t) {
                 throw {'msg': 'No whitespace allowed in destination', 'start': firstToken.end, 'end': t.start};
             } else {
                 throw {'msg': 'Out of data - incomplete destination', 'start': firstToken.start};
             }
         }
-        nameComponents.push(this.eatToken(TokenKind.IDENTIFIER)); // the non-optional identifier
+        let isDotted = false;
+        nameComponents.push(this.peekDestinationComponentToken(true));
+        while (this.isNextTokenAdjacent() && (this.peekDestinationComponentToken(false) !== null)) {
+            nameComponents.push(this.peekDestinationComponentToken(true));
+        }
         while (this.isNextTokenAdjacent() && this.peekToken(TokenKind.DOT)) {
             currentToken = this.eatToken(TokenKind.DOT);
+            isDotted = true;
             if (!this.isNextTokenAdjacent()) {
                 t = this.peekAtToken();
                 if (t) {
@@ -165,11 +186,15 @@ class InternalParser {
                     throw {'msg': 'Out of data - incomplete destination', 'start': currentToken.start};
                 }
             }
-            nameComponents.push(this.eatToken(TokenKind.IDENTIFIER));
+            nameComponents.push(currentToken);
+            nameComponents.push(this.peekDestinationComponentToken(true));
+            while (this.isNextTokenAdjacent() && (this.peekDestinationComponentToken(false)!==null)) {
+                nameComponents.push(this.peekDestinationComponentToken(true));
+            }
         }
         let type = null;
         // TODO this does not cope with dotted stream names...
-        if (nameComponents.length < 2 || !tapAllowed) {
+        if (!isDotted || !tapAllowed) {
             type = 'destination';
         } else {
             type = 'tap';
@@ -179,7 +204,7 @@ class InternalParser {
             type: type,
             start: firstToken.start,
             end: endpos,
-            name: (type === 'tap' ? 'tap:' : '') + this.tokenListToStringList(nameComponents, '.')
+            name: (type === 'tap' ? 'tap:' : '') + this.tokenListToStringList(nameComponents)
         };
         return destinationObject;
     }
@@ -338,18 +363,41 @@ class InternalParser {
     // appList: app (| app)*
     // A stream may end in a app (if it is a sink) or be followed by
     // a sink channel.
-    private eatAppList(): Parser.AppNode[] {
+    private eatAppList(preceedingSourceChannelSpecified: boolean): Parser.AppNode[] {
         const appNodes: Parser.AppNode[] = [];
+        let usedListDelimiter = -1;
+        let usedStreamDelimiter = -1;
         appNodes.push(this.eatApp());
         while (this.moreTokens()) {
             const t = this.peekAtToken();
             if (this.isKind(t, TokenKind.PIPE)) {
+                if (usedListDelimiter >= 0) {
+                    throw {'msg': 'Don\'t mix pipe and comma', 'start': usedListDelimiter};
+                }
+                usedStreamDelimiter = t.start;
+                this.nextToken();
+                appNodes.push(this.eatApp());
+            } else if (this.isKind(t, TokenKind.COMMA)) {
+                if (preceedingSourceChannelSpecified) {
+                    throw {'msg': 'Don\'t use comma with channels', 'start': t.start};
+                }
+                if (usedStreamDelimiter >= 0) {
+                    throw {'msg': 'Don\'t mix pipe and comma', 'start': usedStreamDelimiter};
+                }
+                usedListDelimiter = t.start;
                 this.nextToken();
                 appNodes.push(this.eatApp());
             } else {
                 // might be followed by sink channel
                 break;
             }
+        }
+        const isFollowedBySinkChannel = this.peekToken(TokenKind.GT);
+        if (isFollowedBySinkChannel && usedListDelimiter >= 0) {
+            throw {'msg': 'Don\'t use comma with channels', 'start': usedListDelimiter};
+        }
+        for (let appNumber = 0; appNumber < appNodes.length; appNumber++) {
+            appNodes[appNumber].nonStreamApp = !preceedingSourceChannelSpecified && !isFollowedBySinkChannel && (usedStreamDelimiter < 0);
         }
         return appNodes;
     }
@@ -449,9 +497,9 @@ class InternalParser {
         if (bridge) {
             // Create a bridge app to hang the source/sink channels off
             this.tokenStreamPointer--; // Rewind so we can nicely eat the sink channel
-            appNodes = [{'name': 'bridge', 'start': this.peekAtToken().start, 'end': this.peekAtToken().end}];
+            appNodes = [{'name': 'bridge', 'start': this.peekAtToken().start, 'end': this.peekAtToken().end, 'nonStreamApp': false}];
         } else {
-            appNodes = this.eatAppList();
+            appNodes = this.eatAppList(sourceChannelNode != null);
         }
         streamNode.apps = appNodes;
         const sinkChannelNode = this.maybeEatSinkChannel();
@@ -552,6 +600,9 @@ class InternalParser {
                                 sinkChannelName = streamdef.sinkChannel.channel.name;
                             }
                             app = streamdef.apps[m];
+                            if (app.nonStreamApp) {
+                                expectedType = 'app';
+                            }
                             options = new Map();
                             optionsranges = new Map();
                             if (app.options) {
@@ -587,7 +638,7 @@ class InternalParser {
                                         '\' (at app position ' + m + ') and app \'' + streamdef.apps[previous].name +
                                         '\' (at app position ' + previous + ') both use it'
                                         : 'App \'' + app.name +
-                                        '\' should be unique within the stream, use a label to differentiate multiple occurrences',
+                                        '\' should be unique within the definition, use a label to differentiate multiple occurrences',
                                     'range': streamObject.range
                                 });
                             } else {
@@ -696,6 +747,7 @@ export namespace Parser {
         options?: Parser.Option[];
         start: number;
         end: number;
+        nonStreamApp?: boolean;
     }
 
     export interface Option {

--- a/ui/src/app/shared/services/tokenizer.spec.ts
+++ b/ui/src/app/shared/services/tokenizer.spec.ts
@@ -93,13 +93,41 @@ describe('tokenizer:', () => {
 
   it('error: unexpected char', () => {
     try {
-      tokens = tokenize(' *');
+      tokens = tokenize(' (');
       fail();
     } catch (error) {
       expect(error.msg).toEqual('TokenizationError: Unexpected character');
       expect(error.start).toEqual(1);
       expect(error.end).toEqual(2);
     }
+  });
+
+  it('channel tokenization', () => {
+    tokens = tokenize(':foo');
+    expect(tokens.length).toEqual(2);
+    expectToken(tokens[0], TokenKind.COLON, 0, 1);
+    expectToken(tokens[1], TokenKind.IDENTIFIER, 1, 4, 'foo');
+    tokens = tokenize(':foo*');
+    expect(tokens.length).toEqual(3);
+    expectToken(tokens[0], TokenKind.COLON, 0, 1);
+    expectToken(tokens[1], TokenKind.IDENTIFIER, 1, 4, 'foo');
+    expectToken(tokens[2], TokenKind.STAR, 4, 5);
+    tokens = tokenize(':foo/');
+    expect(tokens.length).toEqual(3);
+    expectToken(tokens[0], TokenKind.COLON, 0, 1);
+    expectToken(tokens[1], TokenKind.IDENTIFIER, 1, 4, 'foo');
+    expectToken(tokens[2], TokenKind.SLASH, 4, 5);
+    tokens = tokenize(':foo#');
+    expect(tokens.length).toEqual(3);
+    expectToken(tokens[0], TokenKind.COLON, 0, 1);
+    expectToken(tokens[1], TokenKind.IDENTIFIER, 1, 4, 'foo');
+    expectToken(tokens[2], TokenKind.HASH, 4, 5);
+    tokens = tokenize(':*/#');
+    expect(tokens.length).toEqual(4);
+    expectToken(tokens[0], TokenKind.COLON, 0, 1);
+    expectToken(tokens[1], TokenKind.STAR, 1, 2);
+    expectToken(tokens[2], TokenKind.SLASH, 2, 3);
+    expectToken(tokens[3], TokenKind.HASH, 3, 4);
   });
 
   it('option tokenization', () => {
@@ -118,8 +146,6 @@ describe('tokenizer:', () => {
     expect(token.end).toEqual(end);
     if (data) {
       expect(token.data).toEqual(data);
-    } else {
-      expect(token.data).toBeUndefined();
     }
   }
 });

--- a/ui/src/app/shared/services/tokenizer.ts
+++ b/ui/src/app/shared/services/tokenizer.ts
@@ -26,8 +26,12 @@ export enum TokenKind {
     SEMICOLON = ';',
     // REFERENCE = '@',
     DOT = '.',
+    SLASH = '/',
+    STAR = '*',
+    HASH = '#',
     LITERAL_STRING = '<LITERAL_STRING>',
-    EOF = '<EOF>'
+    EOF = '<EOF>',
+    COMMA = ','
 }
 
 export interface Token {
@@ -94,7 +98,7 @@ class Tokenizer {
 
     private isArgValueIdentifierTerminator(ch: string, quoteOpen: boolean): boolean {
         return (ch === '|' && !quoteOpen) || (ch === ';' && !quoteOpen) || ch === '\0' || (ch === ' ' && !quoteOpen) ||
-            (ch === '\t' && !quoteOpen) || (ch === '>' && !quoteOpen) ||
+            (ch === '\t' && !quoteOpen) || (ch === '>' && !quoteOpen) || (ch==',' && !quoteOpen) ||
             ch === '\r' || ch === '\n';
     }
 
@@ -130,7 +134,7 @@ class Tokenizer {
     }
 
     private pushCharToken(tokenkind: TokenKind) {
-        this.tokens.push({'kind': tokenkind, 'start': this.pos, 'end': this.pos + 1});
+        this.tokens.push({'kind': tokenkind,  'data': tokenkind, 'start': this.pos, 'end': this.pos + 1});
         this.pos++;
     }
 
@@ -293,8 +297,20 @@ class Tokenizer {
                 case '>':
                     this.pushCharToken(TokenKind.GT);
                     break;
+                case ',':
+                    this.pushCharToken(TokenKind.COMMA);
+                    break;
                 case ':':
                     this.pushCharToken(TokenKind.COLON);
+                    break;
+                case '/':
+                    this.pushCharToken(TokenKind.SLASH);
+                    break;
+                case '*':
+                    this.pushCharToken(TokenKind.STAR);
+                    break;
+                case '#':
+                    this.pushCharToken(TokenKind.HASH);
                     break;
                 case ';':
                     this.pushCharToken(TokenKind.SEMICOLON);

--- a/ui/src/app/streams/components/flo/graph-to-text.spec.ts
+++ b/ui/src/app/streams/components/flo/graph-to-text.spec.ts
@@ -94,6 +94,49 @@ describe('graph-to-text', () => {
         expect(dsl).toEqual('time --aaa=bbb | log');
     });
 
+    it('non stream apps 1', () => {
+        const appA = createApp('appA');
+        dsl = convertGraphToText(graph);
+        expect(dsl).toEqual('appA');
+    });
+
+    it('non stream apps 2', () => {
+        const appA = createApp('appA');
+        const appB = createApp('appB');
+        dsl = convertGraphToText(graph);
+        expect(dsl).toEqual('appA, appB');
+    });
+
+    it('non stream apps with properties', () => {
+        const appA = createApp('appA');
+        setProperties(appA, new Map([['aaa', 'bbb']]));
+        const appB = createApp('appB');
+        dsl = convertGraphToText(graph);
+        expect(dsl).toEqual('appA --aaa=bbb, appB');
+    });
+
+    it('non stream apps with properties 2', () => {
+        const appA = createApp('appA');
+        setProperties(appA, new Map([['aaa', 'bbb']]));
+        const appB = createApp('appB');
+        const appC = createApp('appC');
+        setProperties(appC, new Map([['ccc', 'ddd']]));
+        setProperties(appC, new Map([['eee', 'fff']]));
+        dsl = convertGraphToText(graph);
+        expect(dsl).toEqual('appA --aaa=bbb, appB, appC --ccc=ddd --eee=fff');
+    });
+
+    it('mix apps/streams on graph', () => {
+        const timeSource = createSource('time');
+        setProperties(timeSource, new Map([['aaa', 'bbb'], ['ccc', 'ddd']]));
+        const logSink = createSink('log');
+        setProperties(logSink, new Map([['eee', 'fff']]));
+        createLink(timeSource, logSink);
+        const appA = createApp('appA');
+        dsl = convertGraphToText(graph);
+        expect(dsl).toEqual('time --aaa=bbb --ccc=ddd | log --eee=fff\nappA');
+    });
+
     it('basic - multiple properties', () => {
         const timeSource = createSource('time');
         setProperties(timeSource, new Map([['aaa', 'bbb'], ['ccc', 'ddd']]));
@@ -588,6 +631,10 @@ describe('graph-to-text', () => {
         const newTapNode: dia.Element = createNode('tap', 'tap');
         newTapNode.attr('props/name', tappedStreamAndApp);
         return newTapNode;
+    }
+
+    function createApp(appname: string): dia.Element {
+        return createNode(appname, 'app');
     }
 
     function createSource(appname: string): dia.Element {

--- a/ui/src/app/streams/components/flo/graph-to-text.ts
+++ b/ui/src/app/streams/components/flo/graph-to-text.ts
@@ -58,6 +58,7 @@ class GraphToTextConverter {
 
     public walkGraph(): string {
         const streams: dia.Cell[][] = [];
+        const appStream: dia.Cell[] = [];
         const tapStreams: number[] = [];
         let stream: dia.Cell[];
         for (let n = 0; n < this.nodeCount; n++) {
@@ -70,8 +71,12 @@ class GraphToTextConverter {
             // What to do depends on the combination of in/out links
             if (linksIn.length === 0) {
                 if (linksOut.length === 0) {
-                    // Isolated node, let's put it in the DSL so it is not lost, the graph is a work in progress.
-                    streams.push([node]);
+                    if (node.attr('metadata/group') === 'app') {
+                        appStream.push(node);
+                    } else {
+                        // Isolated node, let's put it in the DSL so it is not lost, the graph is a work in progress.
+                        streams.push([node]);
+                    }
                 } else {
                     if (this.areAllTapLinks(linksOut)) {
                         // Special case, a bit like above it is an isolated node (the stream is actually
@@ -121,6 +126,9 @@ class GraphToTextConverter {
                     }
                 }
             }
+        }
+        if (appStream.length !== 0) {
+            streams.push(appStream);
         }
 
         this.ensureStreamHeadsNamedWhereNecessary(streams, tapStreams);
@@ -218,7 +226,11 @@ class GraphToTextConverter {
                     if (this.isChannel(node) || this.isChannel(stream[i + 1])) {
                         text += ' > ';
                     } else {
-                        text += ' | ';
+                        if (node.attr('metadata/group') === 'app') {
+                            text += ', ';
+                        } else {
+                            text += ' | ';
+                        }
                     }
                 } else if (node.attr('metadata/name') === 'tap') {
                     text += ' >'; // the graph isn't well formed but convenient to put this on end of DSL

--- a/ui/src/app/streams/components/flo/support/node-helper.ts
+++ b/ui/src/app/streams/components/flo/support/node-helper.ts
@@ -36,7 +36,7 @@ const DECORATION_ICON_MAP = new Map<string, string>()
 
 // Default icons (unicode chars) for each group member, unless they override
 const GROUP_ICONS = new Map<string, string>()
-  .set('app', '■') // U+25A0
+  .set('app', '⌸') // U+2338 (Quad equal symbol)
   .set('source', '⤇')// 2907
   .set('processor', 'λ') // 3bb  //flux capacitor? 1D21B
   .set('sink', '⤇') // 2907

--- a/ui/src/app/streams/components/flo/text-to-graph.spec.ts
+++ b/ui/src/app/streams/components/flo/text-to-graph.spec.ts
@@ -63,6 +63,17 @@ describe('text-to-graph', () => {
         expect(graph.links[1].to).toEqual(1);
     });
 
+    it('jsongraph: two separate apps should be unconnected', () => {
+        graph = getGraph('aaa, bbb');
+        expect(graph.streamdefs.length).toEqual(1);
+        expect(graph.streamdefs[0].def).toEqual('aaa, bbb');
+        expect(graph.nodes[0].name).toEqual('aaa');
+        expect(graph.nodes[0].group).toEqual('app');
+        expect(graph.nodes[1].name).toEqual('bbb');
+        expect(graph.nodes[1].group).toEqual('app');
+        expect(graph.links.length).toEqual(0);
+    });
+
     it('jsongraph: tapping a stream', () => {
         graph = getGraph('aaaa= time | log\n:aaaa.time>log');
         expect(graph.streamdefs[0].def).toEqual('time | log');

--- a/ui/src/app/streams/components/flo/text-to-graph.ts
+++ b/ui/src/app/streams/components/flo/text-to-graph.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,23 +167,30 @@ class TextToGraphConverter {
                           parsedNode.name === 'bridge') &&
                         parsedNode.name) {
                         if (n > 0) {
-                            streamdef = streamdef + '| ';
+                            if (parsedNode.type !== 'app') {
+                                streamdef = streamdef + '| ';
+                            } else {
+                                streamdef = streamdef + ', ';
+                            }
                         }
                         graphNode = {
                             'id': nodeId++,
                             'label': parsedNode.label,
                             'name': parsedNode.name,
+                            'group': parsedNode.type,
                             'range': parsedNode.range
                             };
-                        if (linkFrom !== -1) {
-                            newlink = {'from': linkFrom, 'to': graphNode.id};
-                            if (linkCount === 0 && linkType) {
-                                newlink.linkType = linkType;
+                        if (parsedNode.type !== 'app') {
+                            if (linkFrom !== -1) {
+                                newlink = {'from': linkFrom, 'to': graphNode.id};
+                                if (linkCount === 0 && linkType) {
+                                    newlink.linkType = linkType;
+                                }
+                                links.push(newlink);
+                                linkCount++;
                             }
-                            links.push(newlink);
-                            linkCount++;
+                            linkFrom = graphNode.id;
                         }
-                        linkFrom = graphNode.id;
                         if (!nameSet && parsedNode.group) {
                             nameSet = true;
                             streamName = parsedNode.group;
@@ -198,7 +205,7 @@ class TextToGraphConverter {
                         if (parsedNode.label) {
                             streamdef = streamdef + parsedNode.label + ': ';
                         }
-                        streamdef = streamdef + graphNode.name + ' ';
+                        streamdef = streamdef + graphNode.name + ((parsedNode.type !== 'app')?' ':'');
                         if (parsedNode.options.size !== 0) {
                             graphNode.properties = parsedNode.options;
                             graphNode.propertiesranges = parsedNode.optionsranges;
@@ -347,7 +354,7 @@ class TextToGraphConverter {
         for (let n = 0; n < inputnodesCount; n++) {
             const name = inputnodes[n].name;
             const label = inputnodes[n].label;
-            let group = inputnodes[n].group;
+            let group = null;//Ignore inputnodes[n].group; - instead compute the right result in matchGroup
             if (!group) {
                 group = this.matchGroup(name, incoming[n], outgoing[n]);
             }


### PR DESCRIPTION
Alex - can you give this a review, maybe kick the tires. I know there are a few bits of code I could delete to tidy it up. I haven't tried it in the UI yet but the tests are passing for text-to-graph/graph-to-text, parsing/tokenization of the new DSL support (comma separated apps). I haven't done any validation changes yet.  This also adds support for including /#* in channel names (:foo.* > boo > :a/b/c/d)